### PR TITLE
#267 MAPPING.CONFIG not found when calling genabout.py from different directory

### DIFF
--- a/about_code_tool/genabout.py
+++ b/about_code_tool/genabout.py
@@ -739,7 +739,8 @@ def main(parser, options, args):
             print("ERROR: LICENSE_TEXT_LOCATION path does not exist.")
             sys.exit(errno.EINVAL)
 
-    if mapping_config and not path_exists('MAPPING.CONFIG'):
+    mapping_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'MAPPING.CONFIG')
+    if mapping_config and not path_exists(mapping_config_path):
             print("ERROR: The file 'MAPPING.CONFIG' does not exist.")
             sys.exit(errno.EINVAL)
 

--- a/about_code_tool/util.py
+++ b/about_code_tool/util.py
@@ -46,7 +46,7 @@ def path_exists(location):
     """
     Return True if the path exists.
     """
-    return location and  os.path.exists(abspath(location))
+    return location and os.path.exists(abspath(location))
 
 
 def canonical_path(location):


### PR DESCRIPTION
`genabout.py` now looks for `MAPPING.CONFIG` in the same directory where it is.