### PR TITLE
Updating with link to SPEC on version 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ In addition, this tool is able to generate attribution notices and
 identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
-This version of the AboutCode Toolkit follows the ABOUT specification version 2.0 at:
-https://github.com/nexB/aboutcode-toolkit/blob/master/SPEC
+This version of the AboutCode Toolkit follows the ABOUT specification version 3.0 at:
+https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst
 
 
 REQUIREMENTS


### PR DESCRIPTION
The link was broken, and no longer 2.0 seems to be the most up-to-date. Please correct if wrong, thanks.