### PR TITLE
Check license_expressions validity #337 

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,7 @@
     * `check` command will not counted INFO message as error when `--verbose` is set
     * Update `track_change` to `track_changes`
     * Support `author_file`
+    * Add `--check-licenses` option to the `check` command
 
 2018-6-25
 


### PR DESCRIPTION
This is for #337
 * Add the `--check-licenses` options
 * Since the `license_expression` is not a required key, the tool will
not check or prompt error if this field does not present.

Signed-off-by: Chin Yeung Li <tli@nexb.com>