### PR TITLE
Improve boolean field handling #327

### DIFF
--- a/src/attributecode/util.py
+++ b/src/attributecode/util.py
@@ -49,8 +49,10 @@ except ImportError:
 from attributecode import CRITICAL, INFO
 from attributecode import Error
 
-
 on_windows = 'win32' in sys.platform
+
+# boolean field name
+boolean_fields = ['redistribute', 'attribute', 'track_change', 'modified']
 
 
 def to_posix(path):
@@ -123,6 +125,20 @@ def check_file_names(paths):
             seen[path] = orig_path
     return errors
 
+def wrap_boolean_value(context):
+    updated_context = ''
+    for line in context.splitlines():
+        """
+        wrap the boolean value in quote
+        """
+        key = line.partition(':')[0]
+        value = line.partition(':')[2].strip()
+        if key in boolean_fields and value:
+            value = '"' + value + '"'
+            updated_context += key + ': ' + value + '\n'
+        else:
+            updated_context += line + '\n'
+    return updated_context
 
 def check_duplicate_keys_about_file(context):
     keys = []

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -181,3 +181,20 @@ class GenTest(unittest.TestCase):
         expected = ['a', 'b', 'd', 'c']
         results = gen.deduplicate(items)
         assert expected == results
+
+    def test_boolean_value_not_lost(self):
+        location = get_test_loc('gen/inv6.csv')
+        base_dir = get_temp_dir()
+
+        errors, abouts = gen.generate(location, base_dir)
+
+        in_mem_result = [a.dumps(with_absent=False, with_empty=False)
+                        for a in abouts][0]
+        expected = (u'about_resource: .\n'
+                    u'name: AboutCode\n'
+                    u'about_resource_path: .\n'
+                    u'version: 0.11.0\n'
+                    u'redistribute: yes\n'
+                    u'attribute: yes\n'
+                    u'modified: no\n')
+        assert expected == in_mem_result

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -606,7 +606,7 @@ copyright: Copyright (c) 2013-2014 nexB Inc.
 notice_file: NOTICE
 notice_url:
 redistribute:
-attribute:
+attribute: yes
 track_change:
 modified:
 changelog_file:

--- a/tests/testdata/gen/inv6.csv
+++ b/tests/testdata/gen/inv6.csv
@@ -1,0 +1,2 @@
+about_file_path,about_resource,name,version,download_url,description,homepage_url,notes,license_name,license_file,license_url,copyright,notice_file,notice_url,redistribute,attribute,track_change,modified,changelog_file,owner,owner_url,contact,author,vcs_tool,vcs_repository,vcs_path,vcs_tag,vcs_branch,vcs_revision,checksum_md5,checksum_sha1,spec_version
+inv/this.ABOUT,.,AboutCode,0.11.0,,,,,,,,,,,Yes,Y,,N,,,,,,,,,,,,,,


### PR DESCRIPTION
Fixed the bugs that's reported in the comment on Jun 12 in #327

It will now report the 'no' in both `gen` and `inventory`.
After some thought, I think we should just keep the `y, yes, n, no` and
ignore everything else. Some users may use 'x' to represent False and
'tick' as True, so we cannot assume 'x' to be True.
Current behavior:
`y or yes` will consider as True
`n or no` will consider as False
'blank' will gives warning saying the field is present but empty


Signed-off-by: Chin Yeung Li <tli@nexb.com>