### PR TITLE
Support spaces in filename #310 

### DIFF
--- a/src/attributecode/__init__.py
+++ b/src/attributecode/__init__.py
@@ -22,9 +22,9 @@ from collections import namedtuple
 import logging
 
 try:
-    basestring  # Python 2
+    unicode  # Python 2
 except NameError:
-    basestring = str  # Python 3 #NOQA
+    unicode = str  # Python 3 #NOQA
 
 
 __version__ = '3.3.0'
@@ -52,10 +52,11 @@ class Error(namedtuple('Error', ['severity', 'message'])):
     """
     def __new__(self, severity, message):
         if message:
-            if isinstance(message, basestring):
+            if isinstance(message, unicode):
                 message = clean_string(message)
             else:
-                message = clean_string(repr(message))
+                message = clean_string(unicode(repr(message), encoding='utf-8'))
+                message = message.strip('"')
 
         return super(Error, self).__new__(
             Error, severity, message)

--- a/src/attributecode/util.py
+++ b/src/attributecode/util.py
@@ -83,7 +83,7 @@ UNC_PREFIX = u'\\\\?\\'
 UNC_PREFIX_POSIX = to_posix(UNC_PREFIX)
 UNC_PREFIXES = (UNC_PREFIX_POSIX, UNC_PREFIX,)
 
-valid_file_chars = string.digits + string.ascii_letters + '_-.'
+valid_file_chars = string.digits + string.ascii_letters + '_-.' + ' '
 
 
 def invalid_chars(path):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -171,6 +171,11 @@ class UtilsTest(unittest.TestCase):
         expected = []
         assert expected == result
 
+    def test_space_is_valid_chars(self):
+        result = util.invalid_chars(' ')
+        expected = []
+        assert expected == result
+
     def test_invalid_chars_with_invalid_in_name_and_dir(self):
         result = util.invalid_chars('_$as/afg:')
         expected = [':']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -226,8 +226,11 @@ class UtilsTest(unittest.TestCase):
             'locations/dir2/file1',
             'Accessibilité/ périmètre'
         ]
-
-        expected = [Error(CRITICAL, "Invalid characters 'éè' in file name at: 'Accessibilité/ périmètre'")]
+        import sys
+        if sys.version_info[0] < 3: #python2
+            expected = [Error(CRITICAL, b"Invalid characters '\xe9\xe8' in file name at: 'Accessibilit\xe9/ p\xe9rim\xe8tre'")]
+        else:
+            expected = [Error(CRITICAL, "Invalid characters 'éè' in file name at: 'Accessibilité/ périmètre'")]
         result = util.check_file_names(paths)
 
         assert expected[0].message == result[0].message

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -187,9 +187,9 @@ class UtilsTest(unittest.TestCase):
         expected = ['%', '!', '(', ')', '$', '$', ':']
         assert expected == result
 
-    def test_invalid_chars_with_space(self):
+    def test_invalid_chars_with_space_is_valid(self):
         result = util.invalid_chars('_ Hello')
-        expected = [' ']
+        expected = []
         assert expected == result
 
     def test_check_file_names_with_dupes_return_errors(self):
@@ -223,10 +223,11 @@ class UtilsTest(unittest.TestCase):
             'locations/file',
             'locations/file with space',
             'locations/dir1/dir2/file1',
-            'locations/dir2/file1'
+            'locations/dir2/file1',
+            'Accessibilité/ périmètre'
         ]
 
-        expected = [Error(CRITICAL, "Invalid characters '  ' in file name at: 'locations/file with space'")]
+        expected = [Error(CRITICAL, "Invalid characters 'éè' in file name at: 'Accessibilité/ périmètre'")]
         result = util.check_file_names(paths)
 
         assert expected[0].message == result[0].message


### PR DESCRIPTION
The spec does not state if spaces are supported. The previous code will
throw the following critical error if space is detected in file name:
```
CRITICAL: Invalid characters '  ' in file name at: 
```

This commit add ' ' as a valid character.

Signed-off-by: Chin Yeung Li <tli@nexb.com>