### PR TITLE
Add a `from_dict` constructor on the `About` class

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,8 @@ fi
 
 CONFIGURE_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python "$CONFIGURE_ROOT_DIR/etc/configure.py" $CFG_CMD_LINE_ARGS
-if [ -f "$CONFIGURE_ROOT_DIR/bin/activate" ]; then
-    source $CONFIGURE_ROOT_DIR/bin/activate
+if [[ "$PYTHON_EXE" == "" ]]; then
+    PYTHON_EXE=python
 fi
+
+$PYTHON_EXE "$CONFIGURE_ROOT_DIR/etc/configure.py" $CFG_CMD_LINE_ARGS

--- a/src/attributecode/model.py
+++ b/src/attributecode/model.py
@@ -987,6 +987,15 @@ class About(object):
         self.errors = errors
         return errors
 
+    @classmethod
+    def from_dict(cls, about_data, base_dir=''):
+        """
+        Return an About object loaded from a python dict.
+        """
+        about = cls()
+        about.load_dict(about_data, base_dir=base_dir)
+        return about
+
     def dumps(self):
         """
         Return self as a formatted ABOUT string.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -849,6 +849,31 @@ custom1: |
 
         assert expected == dict(as_dict)
 
+    def test_about_model_class_from_dict_constructor(self):
+        about_data = {
+            'about_resource': ['.'],
+            'attribute': 'yes',
+            'author': ['Jillian Daguil, Chin Yeung Li, Philippe Ombredanne, Thomas Druez'],
+            'copyright': 'Copyright (c) 2013-2014 nexB Inc.',
+            'description': 'AboutCode is a tool to process ABOUT files. An ABOUT file is a file.',
+            'homepage_url': 'http://dejacode.org',
+            'license_expression': 'apache-2.0',
+            'name': 'AboutCode',
+            'owner': 'nexB Inc.',
+            'vcs_repository': 'https://github.com/dejacode/about-code-tool.git',
+            'vcs_tool': 'git',
+            'version': '0.11.0',
+        }
+
+        about = model.About.from_dict(about_data)
+        assert isinstance(about, model.About)
+
+        about_data.update({
+            'about_file_path': None,
+            'about_resource': OrderedDict([('.', None)]),
+        })
+        assert about_data == about.as_dict()
+
     def test_write_output_csv(self):
         path = 'test_model/this.ABOUT'
         test_file = get_test_loc(path)


### PR DESCRIPTION
This simplify the construction of .ABOUT file output when using aboutcode-toolkit as a library.